### PR TITLE
Set Provider to Kind

### DIFF
--- a/pkg/cmd/config/set.go
+++ b/pkg/cmd/config/set.go
@@ -86,7 +86,7 @@ func setContext(req *setContextRequest) {
 	}
 	switch req.Provider {
 	case s3.Kind, "aws":
-		nc.Config = stow.ConfigMap{}
+		nc.Provider = s3.Kind
 		if req.s3ConfigAccessKeyID != "" {
 			nc.Config[s3.ConfigAccessKeyID] = req.s3ConfigAccessKeyID
 		}
@@ -100,6 +100,7 @@ func setContext(req *setContextRequest) {
 			nc.Config[s3.ConfigSecretKey] = req.s3ConfigSecretKey
 		}
 	case gcs.Kind, "gs":
+		nc.Provider = gcs.Kind
 		if req.gcsConfigJSONKeyPath != "" {
 			jsonKey, err := ioutil.ReadFile(req.gcsConfigJSONKeyPath)
 			term.ExitOnError(err)


### PR DESCRIPTION
Stow register Location with kind "s3", "google", etc. 
So need to provide these kind. 
 
```go
    switch req.Provider {
    // allow "aws", but always set s3.Kind
    case s3.Kind, "aws":
    // allow "gs", but always set gcs.Kind
    case gcs.Kind, "gs":
```

Otherwise, It gives error
```bash
stow: unknown kind "gs"
```
